### PR TITLE
Fix trace bloat in purchase confirmation handler

### DIFF
--- a/order-api/src/main/java/com/dtcookie/shop/frontend/FrontendServer.java
+++ b/order-api/src/main/java/com/dtcookie/shop/frontend/FrontendServer.java
@@ -113,13 +113,18 @@ public class FrontendServer {
 			span.setAttribute("product.name", product.getName());
 			reportPurchases(product);
 			reportActualRevenue(product);
-			for (int i = 0; i < 50; i++) {
-				Span childSpan = tracer.spanBuilder("persist-purchase-confirmation-" + i).setParent(Context.current().with(span)).startSpan();
-				try {
-					Thread.sleep(1);
-				} finally {
-					childSpan.end();
-				}
+			
+			// Consolidate batch persistence into single span to avoid trace bloat
+			Span persistSpan = tracer.spanBuilder("persist-purchase-confirmation-batch")
+				.setParent(Context.current().with(span))
+				.startSpan();
+			try {
+				// Simulate batch persistence operation (50 iterations consolidated)
+				Thread.sleep(50);
+				persistSpan.addEvent("batch-persistence-completed", 
+					Attributes.of(AttributeKey.longKey("batch.size"), 50L));
+			} finally {
+				persistSpan.end();
 			}
 		} catch (Exception e) {
 			span.recordException(e);


### PR DESCRIPTION
## Problem

The `handlePurchaseConfirmed` method in `FrontendServer.java` was creating **50 individual child spans** for each purchase confirmation, causing significant trace bloat:

- Each request generated 50 spans named `persist-purchase-confirmation-0` through `persist-purchase-confirmation-49`
- Total sleep time: 50ms (1ms × 50)
- Resulted in high trace cardinality and storage overhead
- Made traces difficult to read and analyze

## Solution

Consolidated the 50-span loop into a **single batch persistence span**:

```java
// Before: 50 individual spans
for (int i = 0; i < 50; i++) {
    Span childSpan = tracer.spanBuilder("persist-purchase-confirmation-" + i)...
}

// After: 1 consolidated span
Span persistSpan = tracer.spanBuilder("persist-purchase-confirmation-batch")...
persistSpan.addEvent("batch-persistence-completed", 
    Attributes.of(AttributeKey.longKey("batch.size"), 50L));
```

## Benefits

✅ **Reduces span count by 98%** (from 50 to 1 per purchase)  
✅ **Decreases trace storage and processing overhead**  
✅ **Maintains observability** via span event with batch size attribute  
✅ **Preserves timing information** (50ms consolidated sleep)  
✅ **Improves trace readability** and analysis  

## Testing Recommendations

- Verify purchase confirmation flow still works correctly
- Check that traces now show single `persist-purchase-confirmation-batch` span
- Confirm span event includes `batch.size=50` attribute
- Monitor trace backend for reduced ingestion volume

## Impact

This change significantly improves the observability stack performance while maintaining full visibility into the purchase confirmation process.